### PR TITLE
Updated Point.php to stop converting value to float

### DIFF
--- a/src/InfluxDB/Point.php
+++ b/src/InfluxDB/Point.php
@@ -58,7 +58,7 @@ class Point
         $this->fields = $additionalFields;
 
         if ($value) {
-            $this->fields['value'] = (float) $value;
+            $this->fields['value'] = $value;
         }
 
         if ($timestamp && !$this->isValidTimeStamp($timestamp)) {


### PR DESCRIPTION
Converting a value to a float causes a conflict "field type conflict: input field "value" on measurement "datapoints" is type int64, already exists as type float". For example, If I send 2.01, it works. However, if I send 2.00, it converts it into 2 and then Influxdb treats it as an integer.