### PR TITLE
Allow falsey value to be written

### DIFF
--- a/src/InfluxDB/Point.php
+++ b/src/InfluxDB/Point.php
@@ -57,7 +57,7 @@ class Point
         $this->tags = $tags;
         $this->fields = $additionalFields;
 
-        if ($value) {
+        if ($value !== null) {
             $this->fields['value'] = $value;
         }
 


### PR DESCRIPTION
Currently you cannot write a (integer) 0, or (boolean) false value. There are various reasons why you would want to record a falsey value in the database.