### PR TITLE
Fix multi-point encoding on windows

### DIFF
--- a/src/InfluxDB/Client.php
+++ b/src/InfluxDB/Client.php
@@ -224,7 +224,7 @@ class Client
         $driver->setParameters($parameters);
 
         // send the points to influxDB
-        $driver->write(implode(PHP_EOL, $payload));
+        $driver->write(implode("\n", $payload));
 
         return $driver->isSuccess();
     }


### PR DESCRIPTION
Fixes #24. According to https://influxdb.com/docs/v0.9/write_protocols/line.html separator must be `\n`.